### PR TITLE
Replace scroll gradient mask with inner shadow

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -95,7 +95,7 @@ main {
   --color-blue-700: rgba(var(--color-blue-base), 0.7);
   --color-blue-500: rgba(var(--color-blue-base), 0.5);
   --color-blue-100: rgba(var(--color-blue-base), 0.1);
-  --color-blue-10: #rgba(var(--color-blue-base), 0.01);
+  --color-blue-10: rgba(var(--color-blue-base), 0.01);
   --color-orange: #ce5d24;
   --color-white: #fff;
 
@@ -314,25 +314,10 @@ section {
 
 .tagList {
   -ms-overflow-style: none;
-  -webkit-mask-image: linear-gradient(
-    to right,
-    transparent 0%,
-    #000 15%,
-    #000 85%,
-    transparent 100%
-  );
-
   font-size: 0;
   list-style: none;
   margin: 0 0 8px;
   padding: 0 var(--tile-padding-x);
-  mask-image: linear-gradient(
-    to right,
-    transparent 0%,
-    #000 15%,
-    #000 85%,
-    transparent 100%
-  );
   overflow: scroll;
   scrollbar-width: none;
   white-space: nowrap;


### PR DESCRIPTION
It looks better and there's a bug on iOS where masked items scale up 1.2x when out of bounds